### PR TITLE
Make gfx_3ds struct an extern.

### DIFF
--- a/src/pc/gfx/gfx_3ds.h
+++ b/src/pc/gfx/gfx_3ds.h
@@ -5,6 +5,6 @@
 
 #define N3DS_USE_ANTIALIASING
 
-struct GfxWindowManagerAPI gfx_3ds;
+extern struct GfxWindowManagerAPI gfx_3ds;
 
 #endif


### PR DESCRIPTION
I was getting compiling errors because gfx_3ds is defined in multiple locations.