### PR TITLE
Updating Dockerfile for 3DS build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,21 @@ RUN apt-get update && \
         wget \
         zlib1g-dev
 
-RUN wget \
-        https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb \
-        -O qemu.deb && \
-    echo 8170f37cf03a08cc2d7c1c58f10d650ea0d158f711f6916da9364f6d8c85f741 qemu.deb | sha256sum --check && \
-    dpkg -i qemu.deb && \
-    rm qemu.deb
+RUN wget https://github.com/devkitPro/pacman/releases/download/v1.0.2/devkitpro-pacman.amd64.deb \
+  -O devkitpro.deb && \
+  echo ebc9f199da9a685e5264c87578efe29309d5d90f44f99f3dad9dcd96323fece3 devkitpro.deb | sha256sum --check && \
+  apt install -y ./devkitpro.deb && \
+  rm devkitpro.deb
+
+RUN dkp-pacman -Syu 3ds-dev --noconfirm
 
 RUN mkdir /sm64
 WORKDIR /sm64
-ENV PATH="/sm64/tools:${PATH}"
+
+ENV PATH="/opt/devkitpro/tools/bin/:/sm64/tools:${PATH}"
+ENV DEVKITPRO=/opt/devkitpro
+ENV DEVKITARM=/opt/devkitpro/devkitARM
+ENV DEVKITPPC=/opt/devkitpro/devkitPPC
 
 CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4\n' \
          'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'


### PR DESCRIPTION
This closes https://github.com/sm64-port/sm64_3ds/issues/12

Changes are based upon the [handholding guide](https://github.com/sm64-port/sm64_3ds/issues/7) from @j0w0

FYI - I helped with the [original Dockerfile](https://github.com/n64decomp/sm64/pull/36) in sm64

Tested locally:

```sh
$ sha256sum build/us_3ds/sm64.us.f3dex2e.3dsx
76bde4c99a17f3a1d2d65e4f55efda058581904021ce59053d42a4c25578a46f  build/us_3ds/sm64.us.f3dex2e.3dsx
```